### PR TITLE
fix: Repair and wire the unused utils.rs helpers (#35)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,12 @@ fn render_entries(
         let output_path = PathBuf::from(&config.output).join(&filename);
 
         if config.verbose {
-            eprintln!("Processing: {} -> {}", entry.key, filename);
+            eprintln!(
+                "Processing: {} ({}) -> {}",
+                entry.key,
+                utils::truncate(&entry.title, 60),
+                filename
+            );
         }
 
         if config.dry_run {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,7 +175,12 @@ impl BibTeXParser {
         Ok(parsed_entries)
     }
 
-    /// Parse all BibTeX files in a directory
+    /// Parse all BibTeX files in a directory.
+    ///
+    /// Every discovered file is read through [`crate::utils::safe_read`] with
+    /// the scanned directory as the permitted root, so a `.bib` file that
+    /// resolves outside the directory, for example through a symbolic link,
+    /// is rejected rather than followed (NON-FUNC-4).
     pub fn parse_directory<P: AsRef<Path>>(path: P, recursive: bool) -> Result<Vec<BibTeXEntry>> {
         let path = path.as_ref();
 
@@ -204,9 +209,12 @@ impl BibTeXParser {
             Self::collect_bib_files_flat(path)?
         };
 
-        // Parse each file and fail immediately if any file cannot be parsed.
+        // Parse each file and fail immediately if any file cannot be read
+        // within the scanned directory or cannot be parsed.
         for file in bib_files {
-            let file_entries = Self::parse_file(&file)
+            let content = crate::utils::safe_read(&file, path)
+                .with_context(|| format!("Failed to read BibTeX file: {}", file.display()))?;
+            let file_entries = Self::parse_str(&content)
                 .with_context(|| format!("Failed to parse BibTeX file: {}", file.display()))?;
             entries.extend(file_entries);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,26 +13,6 @@ use uuid::Uuid;
 
 use crate::config::FileNameStrategy;
 
-/// Securely read a file, preventing path traversal attacks
-pub fn safe_read<P: AsRef<Path>>(path: P) -> Result<String> {
-    let path = path.as_ref();
-
-    // Get canonical path to prevent path traversal.
-    let canonical = path.canonicalize().context("Failed to resolve path")?;
-
-    // Resolve parent to force normalisation and surface invalid paths.
-    if let Some(parent) = canonical.parent() {
-        let parent_canonical = parent
-            .canonicalize()
-            .context("Failed to resolve parent directory")?;
-
-        // Placeholder for an allowlist root check.
-        let _ = parent_canonical;
-    }
-
-    fs::read_to_string(&canonical).context(format!("Failed to read file: {}", path.display()))
-}
-
 /// Securely write content to a file, creating parent directories as needed
 pub fn safe_write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, content: C) -> Result<()> {
     let path = path.as_ref();
@@ -82,19 +62,6 @@ pub fn join_path<P1: AsRef<Path>, P2: AsRef<Path>>(base: P1, child: P2) -> PathB
     base.as_ref().join(child.as_ref())
 }
 
-/// Create a temporary file
-pub fn create_temp_file(prefix: &str, suffix: &str) -> Result<(PathBuf, fs::File)> {
-    let temp_dir = std::env::temp_dir();
-    let stem_value = stem(Path::new(suffix)).unwrap_or_else(|| "file".to_string());
-    let filename = format!("{}_{}", prefix, stem_value);
-    let path = temp_dir.join(filename);
-
-    let file = fs::File::create(&path)
-        .context(format!("Failed to create temp file: {}", path.display()))?;
-
-    Ok((path, file))
-}
-
 /// Format a list of strings as a bullet list
 pub fn format_bullet_list(items: &[String]) -> String {
     if items.is_empty() {
@@ -119,15 +86,6 @@ pub fn format_ordered_list(items: &[String]) -> String {
         result.push_str(format!("{}. {}\n", i + 1, item).as_str());
     }
     result
-}
-
-/// Truncate a string to a maximum length, adding ellipsis if needed
-pub fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        return s.to_string();
-    }
-
-    format!("{}...", &s[..max_len.saturating_sub(3)])
 }
 
 /// Sanitize a string for use as a filename
@@ -263,13 +221,6 @@ mod tests {
         assert_eq!(stem("file.txt"), Some("file".to_string()));
         assert_eq!(stem("path/to/file.txt"), Some("file".to_string()));
         assert_eq!(stem("noextension"), Some("noextension".to_string()));
-    }
-
-    #[test]
-    fn test_truncate() {
-        assert_eq!(truncate("hello", 10), "hello");
-        assert_eq!(truncate("hello world", 5), "he...");
-        assert_eq!(truncate("hello", 5), "hello");
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -185,9 +185,12 @@ pub fn format_ordered_list(items: &[String]) -> String {
 /// if content was removed.
 ///
 /// Truncation happens on character boundaries, so multi-byte UTF-8 content
-/// is safe, and the result never exceeds `max_len` characters.
+/// is safe, and the result never exceeds `max_len` characters. At most
+/// `max_len + 1` characters are examined, so the cost is bounded by
+/// `max_len` rather than the input length.
 pub fn truncate(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
+    let exceeds_max = s.char_indices().nth(max_len).is_some();
+    if !exceeds_max {
         return s.to_string();
     }
 
@@ -195,8 +198,12 @@ pub fn truncate(s: &str, max_len: usize) -> String {
         return ".".repeat(max_len);
     }
 
-    let prefix = s.chars().take(max_len - 3).collect::<String>();
-    format!("{}...", prefix)
+    let prefix_end = s
+        .char_indices()
+        .nth(max_len - 3)
+        .map(|(index, _)| index)
+        .unwrap_or(s.len());
+    format!("{}...", &s[..prefix_end])
 }
 
 /// Sanitize a string for use as a filename
@@ -497,6 +504,8 @@ mod tests {
         assert_eq!(truncate("hello", 10), "hello");
         assert_eq!(truncate("hello world", 5), "he...");
         assert_eq!(truncate("hello", 5), "hello");
+        assert_eq!(truncate("hello!", 6), "hello!");
+        assert_eq!(truncate("hello!!", 6), "hel...");
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,14 +92,35 @@ pub fn join_path<P1: AsRef<Path>, P2: AsRef<Path>>(base: P1, child: P2) -> PathB
     base.as_ref().join(child.as_ref())
 }
 
+/// Reject temp file name components that contain path separators, so that a
+/// prefix or suffix can never move the created file out of the temporary
+/// directory (NON-FUNC-4). Both `/` and `\` are rejected on every platform
+/// for consistent cross-platform behaviour.
+fn validate_temp_name_component(label: &str, value: &str) -> Result<()> {
+    if value.contains(['/', '\\']) {
+        anyhow::bail!(
+            "The temp file {} must not contain path separators: {}",
+            label,
+            value
+        );
+    }
+
+    Ok(())
+}
+
 /// Create a uniquely named temporary file in the system temporary directory.
 ///
 /// The suffix is appended verbatim after the unique name component, so an
-/// extension such as `.txt` is preserved in the created file name. The file
-/// is opened with `create_new` (exclusive creation), so an existing file is
+/// extension such as `.txt` is preserved in the created file name. Neither
+/// the prefix nor the suffix may contain path separators, so the file is
+/// always created directly inside the temporary directory. The file is
+/// opened with `create_new` (exclusive creation), so an existing file is
 /// never truncated; on a name collision a different unique name is tried.
 pub fn create_temp_file(prefix: &str, suffix: &str) -> Result<(PathBuf, fs::File)> {
     const MAX_ATTEMPTS: u32 = 1024;
+
+    validate_temp_name_component("prefix", prefix)?;
+    validate_temp_name_component("suffix", suffix)?;
 
     let temp_dir = std::env::temp_dir();
     let pid = std::process::id();
@@ -413,6 +434,23 @@ mod tests {
 
         fs::remove_file(&first_path).ok();
         fs::remove_file(&second_path).ok();
+    }
+
+    #[test]
+    fn test_create_temp_file_rejects_path_separators_in_prefix_and_suffix() {
+        for (prefix, suffix) in [
+            ("../escape", ".txt"),
+            ("/etc/bibtera", ".txt"),
+            ("bibtera", "/etc/passwd"),
+            ("bibtera", "..\\escape.txt"),
+        ] {
+            let error = create_temp_file(prefix, suffix)
+                .expect_err("separator-bearing components must be rejected");
+            assert!(
+                format!("{error:#}").contains("must not contain path separators"),
+                "unexpected error for ({prefix}, {suffix}): {error:#}"
+            );
+        }
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,36 @@ use uuid::Uuid;
 
 use crate::config::FileNameStrategy;
 
+/// Read a file only if it resolves inside the permitted root directory.
+///
+/// Both the requested path and the permitted root are canonicalised before
+/// the containment check, so a path that escapes the root through `..`
+/// components or symbolic links is rejected rather than followed
+/// (NON-FUNC-4).
+pub fn safe_read<P: AsRef<Path>, R: AsRef<Path>>(path: P, allowed_root: R) -> Result<String> {
+    let path = path.as_ref();
+    let allowed_root = allowed_root.as_ref();
+
+    let canonical = path
+        .canonicalize()
+        .context(format!("Failed to resolve path: {}", path.display()))?;
+    let root_canonical = allowed_root.canonicalize().context(format!(
+        "Failed to resolve permitted root directory: {}",
+        allowed_root.display()
+    ))?;
+
+    if !canonical.starts_with(&root_canonical) {
+        anyhow::bail!(
+            "Refusing to read {} because it resolves to {} outside the permitted directory {}",
+            path.display(),
+            canonical.display(),
+            root_canonical.display()
+        );
+    }
+
+    fs::read_to_string(&canonical).context(format!("Failed to read file: {}", path.display()))
+}
+
 /// Securely write content to a file, creating parent directories as needed
 pub fn safe_write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, content: C) -> Result<()> {
     let path = path.as_ref();
@@ -62,6 +92,48 @@ pub fn join_path<P1: AsRef<Path>, P2: AsRef<Path>>(base: P1, child: P2) -> PathB
     base.as_ref().join(child.as_ref())
 }
 
+/// Create a uniquely named temporary file in the system temporary directory.
+///
+/// The suffix is appended verbatim after the unique name component, so an
+/// extension such as `.txt` is preserved in the created file name. The file
+/// is opened with `create_new` (exclusive creation), so an existing file is
+/// never truncated; on a name collision a different unique name is tried.
+pub fn create_temp_file(prefix: &str, suffix: &str) -> Result<(PathBuf, fs::File)> {
+    const MAX_ATTEMPTS: u32 = 1024;
+
+    let temp_dir = std::env::temp_dir();
+    let pid = std::process::id();
+
+    for attempt in 0..MAX_ATTEMPTS {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos())
+            .unwrap_or(0);
+        let filename = format!("{}_{:x}_{:x}_{:x}{}", prefix, pid, nanos, attempt, suffix);
+        let path = temp_dir.join(filename);
+
+        match fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .context(format!("Failed to create temp file: {}", path.display()));
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "Failed to create a unique temp file in {} after {} attempts",
+        temp_dir.display(),
+        MAX_ATTEMPTS
+    )
+}
+
 /// Format a list of strings as a bullet list
 pub fn format_bullet_list(items: &[String]) -> String {
     if items.is_empty() {
@@ -86,6 +158,24 @@ pub fn format_ordered_list(items: &[String]) -> String {
         result.push_str(format!("{}. {}\n", i + 1, item).as_str());
     }
     result
+}
+
+/// Truncate a string to a maximum number of characters, adding an ellipsis
+/// if content was removed.
+///
+/// Truncation happens on character boundaries, so multi-byte UTF-8 content
+/// is safe, and the result never exceeds `max_len` characters.
+pub fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        return s.to_string();
+    }
+
+    if max_len <= 3 {
+        return ".".repeat(max_len);
+    }
+
+    let prefix = s.chars().take(max_len - 3).collect::<String>();
+    format!("{}...", prefix)
 }
 
 /// Sanitize a string for use as a filename
@@ -209,6 +299,147 @@ fn slugify_key(key: &str) -> String {
 mod tests {
     use super::*;
 
+    fn unique_test_dir(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "bibtera_utils_{}_{}_{}",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&dir).expect("create test directory");
+        dir
+    }
+
+    #[test]
+    fn test_safe_read_allows_files_inside_the_permitted_root() {
+        let root = unique_test_dir("safe_read_inside");
+        let file = root.join("inside.bib");
+        fs::write(&file, "content").expect("write test file");
+
+        let read = safe_read(&file, &root).expect("read file inside root");
+        assert_eq!(read, "content");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn test_safe_read_rejects_paths_outside_the_permitted_root() {
+        let root = unique_test_dir("safe_read_root");
+        let outside_dir = unique_test_dir("safe_read_outside");
+        let outside_file = outside_dir.join("outside.bib");
+        fs::write(&outside_file, "secret").expect("write outside file");
+
+        let error = safe_read(&outside_file, &root).expect_err("outside path must be rejected");
+        assert!(
+            format!("{error:#}").contains("outside the permitted directory"),
+            "unexpected error: {error:#}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&outside_dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_safe_read_rejects_symlinks_escaping_the_permitted_root() {
+        let root = unique_test_dir("safe_read_symlink_root");
+        let outside_dir = unique_test_dir("safe_read_symlink_target");
+        let target = outside_dir.join("target.bib");
+        fs::write(&target, "secret").expect("write symlink target");
+
+        let link = root.join("escape.bib");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let error = safe_read(&link, &root).expect_err("escaping symlink must be rejected");
+        assert!(
+            format!("{error:#}").contains("outside the permitted directory"),
+            "unexpected error: {error:#}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+        fs::remove_dir_all(&outside_dir).ok();
+    }
+
+    #[test]
+    fn test_create_temp_file_preserves_suffix_extension() {
+        let (path, _file) = create_temp_file("bibtera_suffix", ".txt").expect("create temp file");
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("temp file name");
+
+        assert!(name.starts_with("bibtera_suffix"), "name: {name}");
+        assert!(name.ends_with(".txt"), "name: {name}");
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_create_temp_file_preserves_full_suffix_including_extension() {
+        let (path, _file) =
+            create_temp_file("bibtera_suffix", "_data.txt").expect("create temp file");
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("temp file name");
+
+        assert!(name.ends_with("_data.txt"), "name: {name}");
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_create_temp_file_repeated_calls_do_not_collide_or_truncate() {
+        use std::io::Write as _;
+
+        let (first_path, mut first_file) =
+            create_temp_file("bibtera_collide", ".tmp").expect("create first temp file");
+        first_file
+            .write_all(b"original")
+            .expect("write first temp file");
+
+        let (second_path, _second_file) =
+            create_temp_file("bibtera_collide", ".tmp").expect("create second temp file");
+
+        assert_ne!(first_path, second_path);
+        assert_eq!(
+            fs::read_to_string(&first_path).expect("read first temp file"),
+            "original"
+        );
+
+        fs::remove_file(&first_path).ok();
+        fs::remove_file(&second_path).ok();
+    }
+
+    #[test]
+    fn test_create_temp_file_concurrent_calls_produce_distinct_paths() {
+        let handles = (0..8)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    create_temp_file("bibtera_concurrent", ".tmp")
+                        .expect("create temp file concurrently")
+                        .0
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let paths = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join temp file thread"))
+            .collect::<Vec<_>>();
+        let unique = paths.iter().collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(unique.len(), paths.len());
+
+        for path in &paths {
+            fs::remove_file(path).ok();
+        }
+    }
+
     #[test]
     fn test_extension() {
         assert_eq!(extension("file.txt"), Some("txt".to_string()));
@@ -221,6 +452,34 @@ mod tests {
         assert_eq!(stem("file.txt"), Some("file".to_string()));
         assert_eq!(stem("path/to/file.txt"), Some("file".to_string()));
         assert_eq!(stem("noextension"), Some("noextension".to_string()));
+    }
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("hello world", 5), "he...");
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_non_ascii_input_is_safe() {
+        // Regression: byte-indexed slicing used to panic inside 'é'.
+        assert_eq!(truncate("héllo wörld", 5), "hé...");
+        assert_eq!(truncate("héllo", 5), "héllo");
+        assert_eq!(truncate("日本語のタイトル", 6), "日本語...");
+    }
+
+    #[test]
+    fn test_truncate_never_exceeds_requested_maximum() {
+        for max_len in 0..8 {
+            let result = truncate("héllo wörld", max_len);
+            assert!(
+                result.chars().count() <= max_len,
+                "truncate to {} produced {:?}",
+                max_len,
+                result
+            );
+        }
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20,7 +20,6 @@ fn unique_temp_file(stem: &str, extension: &str) -> PathBuf {
     path
 }
 
-#[cfg(unix)]
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -599,8 +598,7 @@ fn it_single_mode_context_001_supports_combined_output_naming_inputs() {
     assert_eq!(entries.len(), 2);
 
     let mut engine = TemplateEngine::new().expect("create engine");
-    let temp_output_dir = std::env::temp_dir().join("bibtera_tests_single_mode_test");
-    fs::create_dir_all(&temp_output_dir).ok();
+    let temp_output_dir = unique_temp_dir("single_mode_test");
 
     let temp_template_file = temp_output_dir.join("mytemplate.md");
     let template_content = "# All References\n{% for entry in entries %}\n- {{ entry.key }}: {{ entry.title }}\n{% endfor %}\n";

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,6 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use bibtera::config::FilterConfig;
 use bibtera::parser::BibTeXParser;
@@ -12,17 +11,60 @@ fn examples_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples")
 }
 
-fn temp_dir() -> PathBuf {
-    std::env::temp_dir().join("bibtera_tests")
+fn unique_temp_file(stem: &str, extension: &str) -> PathBuf {
+    let (path, _file) = bibtera::utils::create_temp_file(
+        &format!("bibtera_tests_{}", stem),
+        &format!(".{}", extension),
+    )
+    .expect("create unique temp file");
+    path
 }
 
-fn unique_temp_file(stem: &str, extension: &str) -> PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
+#[cfg(unix)]
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
         .expect("system time before unix epoch")
         .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "bibtera_tests_{}_{}_{}",
+        label,
+        std::process::id(),
+        nonce
+    ));
+    fs::create_dir_all(&dir).expect("create temp directory");
+    dir
+}
 
-    temp_dir().join(format!("{}_{}.{}", stem, nonce, extension))
+#[cfg(unix)]
+#[test]
+fn it_directory_traversal_001_rejects_bib_symlinks_escaping_the_scanned_directory() {
+    let scan_root = unique_temp_dir("traversal_root");
+    let outside_dir = unique_temp_dir("traversal_outside");
+
+    let outside_file = outside_dir.join("outside.bib");
+    fs::write(
+        &outside_file,
+        "@misc{outside2024,\n  title = {Outside}\n}\n",
+    )
+    .expect("write outside fixture");
+    fs::write(
+        scan_root.join("inside.bib"),
+        "@misc{inside2024,\n  title = {Inside}\n}\n",
+    )
+    .expect("write inside fixture");
+    std::os::unix::fs::symlink(&outside_file, scan_root.join("escape.bib"))
+        .expect("create escaping symlink");
+
+    let error = BibTeXParser::parse_directory(&scan_root, false)
+        .expect_err("directory parsing must reject the escaping symlink");
+    assert!(
+        format!("{error:#}").contains("outside the permitted directory"),
+        "unexpected error: {error:#}"
+    );
+
+    fs::remove_dir_all(&scan_root).ok();
+    fs::remove_dir_all(&outside_dir).ok();
 }
 
 #[test]
@@ -99,7 +141,6 @@ fn it_field_whitespace_001_collapses_line_wrapped_field_values() {
 fn it_author_normalisation_001_exposes_author_parts_to_templates() {
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_author_parts", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ author_parts[0].last }}, {{ author_parts[0].first }} - {{ title }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -145,7 +186,6 @@ fn it_nonstandard_fields_001_preserves_non_standard_fields_for_templates() {
 
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_non_standard_fields", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "Abstract: {{ fields.abstract }}\nKeywords: {{ fields.keywords }}\n";
     fs::write(&temp_file, template_content).expect("write template");
@@ -183,7 +223,6 @@ fn it_date_normalisation_001_normalises_month_and_day_values() {
 
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_date_normalisation", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "Month: {{ fields.month }}\nDay: {{ fields.day }}\n";
     fs::write(&temp_file, template_content).expect("write template");
@@ -220,7 +259,6 @@ fn it_slugified_keywords_001_exposes_slugified_keyword_array() {
 
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_slugified_keywords", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content =
         "First: {{ slugified_keywords[0] }}\nAll: {{ slugified_keywords | join(sep=\",\") }}\n";
@@ -259,7 +297,6 @@ fn it_raw_bibtex_001_exposes_raw_bibtex_field() {
 
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_raw_bibtex", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ raw_bibtex }}\n";
     fs::write(&temp_file, template_content).expect("write template");
@@ -336,7 +373,6 @@ fn it_filter_by_type_002_combines_key_and_type_constraints() {
 fn it_latex_substitution_math_mode_001_preserves_math_regions_for_templates() {
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_latex_math_mode", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ latex_substitute(value=title) }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -372,7 +408,6 @@ fn it_latex_substitution_math_mode_001_preserves_math_regions_for_templates() {
 fn it_latex_substitution_math_mode_002_preserves_real_default_map_tokens_in_math_regions() {
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_latex_math_mode_real_tokens", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ latex_substitute(value=title) }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -412,7 +447,6 @@ fn it_latex_substitution_math_mode_003_treats_unclosed_double_dollar_as_plain_te
     let mut engine =
         TemplateEngine::new_with_substitutions(Some(substitutions)).expect("create engine");
     let temp_file = unique_temp_file("it_latex_math_mode_unclosed_double_dollar", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ latex_substitute(value=title) }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -449,7 +483,6 @@ fn it_latex_substitution_cascade_001_does_not_reprocess_replacement_outputs() {
     let mut engine =
         TemplateEngine::new_with_substitutions(Some(substitutions)).expect("create engine");
     let temp_file = unique_temp_file("it_latex_substitution_cascade", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ latex_substitute(value=title) }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -481,7 +514,6 @@ fn it_latex_substitution_cascade_001_does_not_reprocess_replacement_outputs() {
 fn it_latex_substitution_boundary_001_respects_command_token_boundaries() {
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_latex_substitution_boundary", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "{{ latex_substitute(value=title) }}";
     fs::write(&temp_file, template_content).expect("write template");
@@ -528,7 +560,6 @@ fn it_single_mode_context_001_exposes_entries_collection_to_templates() {
 
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_entries_collection", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content =
         "Count: {{ entries | length }}\nKeys: {% for e in entries %}{{ e.key }} {% endfor %}\n";
@@ -568,7 +599,7 @@ fn it_single_mode_context_001_supports_combined_output_naming_inputs() {
     assert_eq!(entries.len(), 2);
 
     let mut engine = TemplateEngine::new().expect("create engine");
-    let temp_output_dir = temp_dir().join("single_mode_test");
+    let temp_output_dir = std::env::temp_dir().join("bibtera_tests_single_mode_test");
     fs::create_dir_all(&temp_output_dir).ok();
 
     let temp_template_file = temp_output_dir.join("mytemplate.md");
@@ -594,7 +625,6 @@ fn it_single_mode_context_001_supports_combined_output_naming_inputs() {
 fn it_error_surfacing_001_exposes_underlying_template_parser_errors() {
     let mut engine = TemplateEngine::new().expect("create engine");
     let temp_file = unique_temp_file("it_invalid_template_comment", "md");
-    fs::create_dir_all(temp_dir()).ok();
 
     let template_content = "<!-- {% alert(type=\"info\") %} -->\nHello\n<!-- {% end %} -->";
     fs::write(&temp_file, template_content).expect("write invalid template");

--- a/tests/specifications/integration-tests.json
+++ b/tests/specifications/integration-tests.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./schemas/scenario-catalogue.schema.json",
-    "version": "v2026-07-20-001",
+    "version": "v2026-07-21-001",
     "scope": "integration",
     "description": "Scenario catalogue for cross-module behaviours that combine parser, template engine and CLI parsing concerns.",
     "required_fields": [
@@ -304,6 +304,20 @@
                 "Math regions in standard formats ($...$, $$...$$, \\(...\\), \\[...\\]) are consistently identified.",
                 "If internal math segment count mismatch is detected, the system falls back to safe content rather than silently dropping math regions.",
                 "Normal cases without mismatch continue to preserve original math content without diagnostic warnings."
+            ]
+        },
+        {
+            "id": "IT-DIRECTORY-TRAVERSAL-001",
+            "objective": "Verify that directory parsing rejects .bib files that resolve outside the scanned directory, for example through symbolic links.",
+            "requirements": [
+                "NON-FUNC-4"
+            ],
+            "fixtures": [
+                "symlinked_escape_directory"
+            ],
+            "expected_outcomes": [
+                "Directory parsing fails with an error identifying that the file resolves outside the permitted directory.",
+                "No entry content sourced from outside the scanned directory is returned."
             ]
         }
     ]

--- a/tests/test-data/fixtures.json
+++ b/tests/test-data/fixtures.json
@@ -1,6 +1,6 @@
 {
     "$schema": "../specifications/schemas/fixture-catalogue.schema.json",
-    "version": "v2026-07-20-003",
+    "version": "v2026-07-21-001",
     "description": "Shared fixture catalogue for integration and end-to-end test specifications.",
     "fixtures": {
         "input_sample_bib": {
@@ -142,6 +142,10 @@
         "representative_random_subset_rule": {
             "kind": "selection-rule",
             "purpose": "Documented rule for choosing a repeatable representative subset when exhaustive output checking is unnecessary."
+        },
+        "symlinked_escape_directory": {
+            "kind": "generated-state",
+            "purpose": "Runtime-created directory containing a symbolic link whose target resolves outside the scanned directory, used for path-traversal rejection scenarios."
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #35. Issue 35 identified three publicly exported helpers in `src/utils.rs` with no call sites in the CLI flow, each carrying a genuine defect. The first commit on this branch removed them; following review, the second commit restores them and takes the issue's other remediation option instead: fix each defect and wire each function into a real call site with regression tests.

- **`truncate`** now counts characters instead of bytes, so multi-byte UTF-8 input no longer panics (`truncate("héllo wörld", 5)` returns `hé...` instead of crashing), and the result never exceeds the requested maximum, including for `max_len < 3`. Wired into the verbose per-entry transform output, which now shows a truncated entry title: `Processing: smith2020machine (Machine Learning for Natural…) -> <file>`.
- **`safe_read`** now takes an explicit permitted root directory and rejects any path whose canonical form resolves outside it, delivering the path-traversal protection its documentation previously only promised (NON-FUNC-4). Wired into `BibTeXParser::parse_directory`, so a symlinked `.bib` file inside a scanned directory cannot read content from outside it. This also gives `parse_directory` — previously untested public API — its first coverage.
- **`create_temp_file`** now appends the suffix verbatim (the extension is preserved instead of being stripped by `stem()`) and creates files exclusively (`create_new`/`O_EXCL`) under a unique per-process name, so existing files are never silently truncated and concurrent calls cannot collide. It replaces the hand-rolled temp-file helper in `tests/integration_tests.rs`, so every integration test now exercises it.

## Tests

- Unit regression tests for the exact failure cases in the issue: non-ASCII truncation, paths and symlinks escaping the permitted root, suffix preservation, repeated and concurrent temp-file creation.
- New integration scenario `IT-DIRECTORY-TRAVERSAL-001` (with its `symlinked_escape_directory` fixture) added to the machine-readable catalogues, verifying that directory parsing rejects a `.bib` symlink that escapes the scanned directory.

## Verification

- `cargo fmt`, `cargo check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 123 tests pass (71 unit, 6 doc, 26 end-to-end, 20 integration), 0 failures
- Manual CLI run of `bibtera transform --verbose` confirms the truncated-title output

## Note on API compatibility

`safe_read`'s signature gains a required `allowed_root` parameter — the documented guarantee is unimplementable without one. Since the crate is at 0.1.x, releasing this as 0.2.0 would be the semver-appropriate step; I have left the version bump to the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)