### PR TITLE
fix: Make .bib extension checks case-insensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ examples/output/
 .env
 
 .claude/*
+.worktrees/

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,10 @@ impl TransformConfig {
 
     /// Validate transform config.
     pub fn validate(&self) -> Result<()> {
-        if !self.input.to_ascii_lowercase().ends_with(".bib") {
+        if !Path::new(&self.input)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("bib"))
+        {
             return Err(ConfigError::Validation(format!(
                 "Input must be a .bib file: {}",
                 self.input
@@ -254,7 +257,10 @@ impl InfoConfig {
     /// Validate info config.
     pub fn validate(&self) -> Result<()> {
         if let Some(input) = &self.input {
-            if !input.to_ascii_lowercase().ends_with(".bib") {
+            if !Path::new(input)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("bib"))
+            {
                 return Err(ConfigError::Validation(format!(
                     "Input must be a .bib file: {}",
                     input

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ impl TransformConfig {
 
     /// Validate transform config.
     pub fn validate(&self) -> Result<()> {
-        if !self.input.ends_with(".bib") {
+        if !self.input.to_ascii_lowercase().ends_with(".bib") {
             return Err(ConfigError::Validation(format!(
                 "Input must be a .bib file: {}",
                 self.input
@@ -254,7 +254,7 @@ impl InfoConfig {
     /// Validate info config.
     pub fn validate(&self) -> Result<()> {
         if let Some(input) = &self.input {
-            if !input.ends_with(".bib") {
+            if !input.to_ascii_lowercase().ends_with(".bib") {
                 return Err(ConfigError::Validation(format!(
                     "Input must be a .bib file: {}",
                     input
@@ -394,5 +394,60 @@ mod tests {
         };
 
         assert!(filter.has_explicit_selection());
+    }
+
+    #[test]
+    fn test_transform_config_validate_accepts_mixed_case_bib_extension() {
+        let (input, _file) =
+            crate::utils::create_temp_file("bibtera_config_tests_transform", ".BIB")
+                .expect("create temp .BIB file");
+
+        let cfg = TransformConfig {
+            input: input.to_string_lossy().into_owned(),
+            output: std::env::temp_dir().to_string_lossy().into_owned(),
+            template: input.to_string_lossy().into_owned(),
+            filter: FilterConfig::default(),
+            dry_run: true,
+            overwrite: false,
+            file_name_strategy: FileNameStrategy::default(),
+            single: false,
+            latex_substitution_map: None,
+            verbose: false,
+        };
+
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_transform_config_validate_rejects_non_bib_extension() {
+        let cfg = TransformConfig {
+            input: "refs.txt".to_string(),
+            output: std::env::temp_dir().to_string_lossy().into_owned(),
+            template: "template.md".to_string(),
+            filter: FilterConfig::default(),
+            dry_run: true,
+            overwrite: false,
+            file_name_strategy: FileNameStrategy::default(),
+            single: false,
+            latex_substitution_map: None,
+            verbose: false,
+        };
+
+        let error = cfg.validate().expect_err("non-.bib input must be rejected");
+        assert!(format!("{error:#}").contains("must be a .bib file"));
+    }
+
+    #[test]
+    fn test_info_config_validate_accepts_mixed_case_bib_extension() {
+        let (input, _file) = crate::utils::create_temp_file("bibtera_config_tests_info", ".Bib")
+            .expect("create temp .Bib file");
+
+        let cfg = InfoConfig {
+            input: Some(input.to_string_lossy().into_owned()),
+            filter: FilterConfig::default(),
+            verbose: false,
+        };
+
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -235,7 +235,11 @@ impl BibTeXParser {
             let entry = entry?;
             let path = entry.path();
 
-            if path.is_file() && path.extension().is_some_and(|ext| ext == "bib") {
+            if path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("bib"))
+            {
                 files.push(path);
             }
         }
@@ -258,7 +262,11 @@ impl BibTeXParser {
             let entry = entry?;
             let path = entry.path();
 
-            if path.is_file() && path.extension().is_some_and(|ext| ext == "bib") {
+            if path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("bib"))
+            {
                 files.push(path);
             } else if path.is_dir() {
                 Self::collect_recursive(&path, files)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -67,6 +67,36 @@ fn it_directory_traversal_001_rejects_bib_symlinks_escaping_the_scanned_director
 }
 
 #[test]
+fn it_directory_extension_case_001_recognises_mixed_case_bib_extensions() {
+    let scan_root = unique_temp_dir("extension_case_root");
+
+    fs::write(
+        scan_root.join("lower.bib"),
+        "@misc{lower2024,\n  title = {Lower}\n}\n",
+    )
+    .expect("write lowercase fixture");
+    fs::write(
+        scan_root.join("upper.BIB"),
+        "@misc{upper2024,\n  title = {Upper}\n}\n",
+    )
+    .expect("write uppercase fixture");
+    fs::write(
+        scan_root.join("mixed.Bib"),
+        "@misc{mixed2024,\n  title = {Mixed}\n}\n",
+    )
+    .expect("write mixed-case fixture");
+
+    let entries =
+        BibTeXParser::parse_directory(&scan_root, false).expect("parse mixed-case directory");
+    let mut keys: Vec<_> = entries.iter().map(|entry| entry.key.clone()).collect();
+    keys.sort();
+
+    assert_eq!(keys, vec!["lower2024", "mixed2024", "upper2024"]);
+
+    fs::remove_dir_all(&scan_root).ok();
+}
+
+#[test]
 fn it_parse_sample_001_parses_sample_bib_fixture() {
     let sample_file = examples_dir().join("input_sample.bib");
     let entries = BibTeXParser::parse_file(&sample_file).expect("parse input_sample.bib");

--- a/tests/specifications/integration-tests.json
+++ b/tests/specifications/integration-tests.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./schemas/scenario-catalogue.schema.json",
-    "version": "v2026-07-21-001",
+    "version": "v2026-07-21-002",
     "scope": "integration",
     "description": "Scenario catalogue for cross-module behaviours that combine parser, template engine and CLI parsing concerns.",
     "required_fields": [
@@ -318,6 +318,19 @@
             "expected_outcomes": [
                 "Directory parsing fails with an error identifying that the file resolves outside the permitted directory.",
                 "No entry content sourced from outside the scanned directory is returned."
+            ]
+        },
+        {
+            "id": "IT-DIRECTORY-EXTENSION-CASE-001",
+            "objective": "Verify that directory parsing recognises .bib files regardless of the case of their extension.",
+            "requirements": [
+                "NON-FUNC-8"
+            ],
+            "fixtures": [
+                "mixed_case_bib_extension_directory"
+            ],
+            "expected_outcomes": [
+                "Files with lowercase, uppercase and mixed-case .bib extensions are all included in the parsed entries."
             ]
         }
     ]

--- a/tests/test-data/fixtures.json
+++ b/tests/test-data/fixtures.json
@@ -1,6 +1,6 @@
 {
     "$schema": "../specifications/schemas/fixture-catalogue.schema.json",
-    "version": "v2026-07-21-001",
+    "version": "v2026-07-21-002",
     "description": "Shared fixture catalogue for integration and end-to-end test specifications.",
     "fixtures": {
         "input_sample_bib": {
@@ -150,6 +150,10 @@
         "symlinked_escape_directory": {
             "kind": "generated-state",
             "purpose": "Runtime-created directory containing a symbolic link whose target resolves outside the scanned directory, used for path-traversal rejection scenarios."
+        },
+        "mixed_case_bib_extension_directory": {
+            "kind": "generated-state",
+            "purpose": "Runtime-created directory containing .bib files with lowercase, uppercase and mixed-case extensions, used for case-insensitive extension scanning scenarios."
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #37: `.bib` extension checks were case-sensitive, so `refs.BIB` or `refs.Bib` (common on case-insensitive filesystems, notably Windows) were rejected or silently skipped.
- `TransformConfig::validate` and `InfoConfig::validate` now compare the extension case-insensitively.
- `BibTeXParser::collect_bib_files_flat` and `collect_recursive` now use `eq_ignore_ascii_case` when matching the file extension.
- Addresses NON-FUNC-8 (cross-platform compatibility).

## Test plan
- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (135 tests passing, including new unit tests for `TransformConfig`/`InfoConfig` validation and a new `IT-DIRECTORY-EXTENSION-CASE-001` integration scenario)
- [x] Manually reproduced the original repro (`bibtera transform -i refs.BIB ...`) and confirmed it now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)